### PR TITLE
fix: set max-width of code blocks

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -89,6 +89,7 @@ const { title } = Astro.props
 
     pre {
         width: fit-content;
+        max-width: -webkit-fill-available;
     }
 
     .is--footer {


### PR DESCRIPTION
Forgot to test on mobile. It should work for any device now.